### PR TITLE
feat(actions): adding some actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,10 +23,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - debian
-          - fedora
-          - ubuntu
-          - archlinux
+          - debian:12.6
+          - ubuntu:24.04
+          - archlinux:latest
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,22 +5,7 @@ on:
   - pull_request
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Install molecule
-        run: |
-          python3 -m pip install --upgrade pip
-          pip install molecule
-      - name: Run molecule lint
-        run: |
-          molecule lint
-
   test:
-    needs:
-      - lint
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,14 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-        with:
-          path: "${{ github.repository }}"
-      - name: molecule
-        uses: robertdebock/molecule-action@6.0.0
-        with:
-          command: lint
+      - name: Install molecule
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install molecule
+      - name: Run molecule lint
+        run: |
+          molecule lint
+
   test:
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+---
+name: CI
+
+on:
+  - pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: robertdebock/molecule-action@6.0.0
+        with:
+          command: lint
+  test:
+    needs:
+      - lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - debian
+          - fedora
+          - ubuntu
+          - archlinux
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: robertdebock/molecule-action@6.0.0
+        with:
+          image: "${{ matrix.image }}"
+          options: parallel
+          scenario: default


### PR DESCRIPTION
This pull request introduces a new continuous integration (CI) workflow configuration using GitHub Actions. The key changes include setting up linting and testing jobs that run on multiple Linux distributions.

CI Workflow Setup:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R40): Added a new CI workflow configuration that triggers on pull requests. It includes a linting job that runs on `ubuntu-latest` and a testing job that runs on a matrix of Linux distributions (Debian, Fedora, Ubuntu, ArchLinux) using the `molecule-action` GitHub Action.