### PR TITLE
feat(shell): adding shell detect

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,11 +37,32 @@
   register: user_shell
   changed_when: false
 
+- name: Determine the appropriate shell configuration file
+  set_fact:
+    shell_config_file: >-
+      {% if user_shell.stdout.endswith('/zsh') %}
+        ~/.zshrc
+      {% elif user_shell.stdout.endswith('/bash') %}
+        ~/.bashrc
+      {% else %}
+        ~/.profile
+      {% endif %}
+
+#- name: Add Homebrew to PATH
+#  ansible.builtin.lineinfile:
+#    path: "{{ shell_config_file }}"
+#    line: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"'
+#    state: present
 - name: Add Homebrew to PATH
   ansible.builtin.lineinfile:
-    path: ~/.profile
-    line: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"'
+    path: "{{ shell_config_file }}"
+    line: >-
+      {% if user_shell.stdout.endswith('/fish') %}
+        eval (/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+      {% else %}
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      {% endif %}
     state: present
-
+    create: true
 - name: Add task to install packages
   ansible.builtin.include_tasks: install-packages.yaml


### PR DESCRIPTION
This pull request includes changes to the `tasks/main.yml` file to improve the setup of the shell configuration for Homebrew. The most important changes include determining the appropriate shell configuration file dynamically and adjusting the Homebrew PATH addition based on the user's shell.

Shell configuration improvements:

* Added a task to set the `shell_config_file` variable based on the user's shell, choosing between `~/.zshrc`, `~/.bashrc`, and `~/.profile`.
* Updated the task to add Homebrew to the PATH to use the dynamically determined `shell_config_file` and handle the `fish` shell differently.